### PR TITLE
Fix: Correct paths for r-lib/actions in CI workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -10,17 +10,16 @@ jobs:
   R-CMD-check:
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Needed to read .ver and commit SHA
-      # contents: write # Only if we were to commit the DESCRIPTION file change back
+      contents: read
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required to get commit SHA
+          fetch-depth: 0
 
       - name: Set up R
-        uses: r-lib/actions/setup-R@v2
+        uses: r-lib/actions/setup-r@v2  # Corrected path
         with:
           r-version: '4.5.0'
 
@@ -44,7 +43,7 @@ jobs:
           cat DESCRIPTION
 
       - name: Install dependencies
-        uses: r-lib/actions/setup-R-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@v2 # Corrected path
         with:
           packages: |
             any::packrat
@@ -53,15 +52,14 @@ jobs:
           needs: check
 
       - name: Check package
-        uses: r-lib/actions/check-R-package@v2
+        uses: r-lib/actions/check-r-package@v2 # Corrected path
         with:
-          upload-snapshots: true # Useful for debugging check failures
+          upload-snapshots: true
 
       - name: Build package
         id: build
         run: |
           R CMD build .
-          # Find the built package name
           PKG_FILE=$(ls *.tar.gz)
           echo "PKG_FILE=$PKG_FILE" >> $GITHUB_OUTPUT
           echo "Built package file: $PKG_FILE"


### PR DESCRIPTION
This commit corrects the `uses:` paths for actions from the `r-lib/actions` repository in the `.github/workflows/R-CMD-check.yml` file.

The following changes were made:
- `r-lib/actions/setup-R@v2` changed to `r-lib/actions/setup-r@v2`
- `r-lib/actions/setup-R-dependencies@v2` changed to `r-lib/actions/setup-r-dependencies@v2`
- `r-lib/actions/check-R-package@v2` changed to `r-lib/actions/check-r-package@v2`

These changes are necessary because the actions within the `r-lib/actions` monorepo are referenced by their specific directory names, which are lowercase. This fix addresses the "Can't find 'action.yml'" error previously encountered during workflow execution.