### PR TITLE
Fix: Correct package specification in CI dependency installation

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -46,9 +46,9 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2 # Corrected path
         with:
           packages: |
-            any::packrat
-            any::rcpp
-            any::plyr
+            packrat
+            rcpp
+            plyr
           needs: check
 
       - name: Check package


### PR DESCRIPTION
This commit fixes an error in the GitHub Actions workflow (`.github/workflows/R-CMD-check.yml`) where R package dependencies were incorrectly specified.

The `any::` prefix was removed from package names in the `r-lib/actions/setup-r-dependencies` step. Packages `packrat`, `rcpp`, and `plyr` are now listed by their standard CRAN names.

This change addresses the error "Can't find package called any::rcpp" encountered during the dependency resolution phase of the CI job.