### PR TITLE
Refactor: Use packrat::restore() for R dependencies in CI

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v2  # Corrected path
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.5.0'
 
@@ -42,17 +42,18 @@ jobs:
           echo "DESCRIPTION file after update:"
           cat DESCRIPTION
 
-      - name: Install dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2 # Corrected path
+      - name: Install system dependencies and packrat
+        uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: |
             packrat
-            rcpp
-            plyr
-          needs: check
+          # Removed rcpp and plyr as packrat::restore() should handle them via packrat.lock
+
+      - name: Restore R package dependencies (packrat)
+        run: Rscript -e "packrat::restore()"
 
       - name: Check package
-        uses: r-lib/actions/check-r-package@v2 # Corrected path
+        uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
 


### PR DESCRIPTION
This commit refactors the GitHub Actions workflow to use `packrat::restore()` for installing R package dependencies, providing a more robust and consistent dependency management approach aligned with the project's use of Packrat.

Changes in `.github/workflows/R-CMD-check.yml`:
- The `r-lib/actions/setup-r-dependencies` step is now configured to primarily install `packrat` itself and handle system-level dependencies.
- A new step `Restore R package dependencies (packrat)` has been added which executes `Rscript -e "packrat::restore()"`. This command uses the project's `packrat.lock` file to install the correct versions of R package dependencies.

This approach aims to resolve previous issues where `pak` (used by `setup-r-dependencies`) had difficulty locating CRAN packages. Using `packrat::restore()` directly leverages the project's existing dependency management setup.