### PR TITLE
Fix: Install rcmdcheck for CI check step

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           packages: |
             packrat
+            rcmdcheck # Added rcmdcheck for the check-r-package action
           # Removed rcpp and plyr as packrat::restore() should handle them via packrat.lock
 
       - name: Restore R package dependencies (packrat)


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to explicitly install the `rcmdcheck` R package. The `r-lib/actions/check-r-package` action relies on `rcmdcheck` to perform its operations.

Changes in `.github/workflows/R-CMD-check.yml`:
- Added `rcmdcheck` to the `packages` list within the `r-lib/actions/setup-r-dependencies` step.

This ensures that `rcmdcheck` is available in the R environment before the package check is initiated, resolving the "there is no package called 'rcmdcheck'" error.