### PR TITLE
Fix: Correct formatting in CI dependency list

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -47,8 +47,10 @@ jobs:
         with:
           packages: |
             packrat
-            rcmdcheck # Added rcmdcheck for the check-r-package action
-          # Removed rcpp and plyr as packrat::restore() should handle them via packrat.lock
+            rcmdcheck
+            # The rcmdcheck package is needed for the check-r-package action.
+            # Other R package dependencies like rcpp and plyr are restored
+            # from packrat.lock in a subsequent step.
 
       - name: Restore R package dependencies (packrat)
         run: Rscript -e "packrat::restore()"


### PR DESCRIPTION
This commit fixes a formatting issue in the `packages` list within the `r-lib/actions/setup-r-dependencies` step of the GitHub Actions workflow (`.github/workflows/R-CMD-check.yml`).

Previously, comments on the same line as package names, or improperly formatted comments, caused `pak` to fail with a parsing error: "Cannot parse packages: # and check-r-package."

Package names (`packrat`, `rcmdcheck`) are now listed one per line, and all comments are on their own separate lines, correctly prefixed. This ensures that `pak` can correctly parse the list of packages to install.