### PR TITLE
Fix: Remove comments from CI dependency list for parser safety

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -48,9 +48,6 @@ jobs:
           packages: |
             packrat
             rcmdcheck
-            # The rcmdcheck package is needed for the check-r-package action.
-            # Other R package dependencies like rcpp and plyr are restored
-            # from packrat.lock in a subsequent step.
 
       - name: Restore R package dependencies (packrat)
         run: Rscript -e "packrat::restore()"


### PR DESCRIPTION
This commit further refines the `packages` list within the `r-lib/actions/setup-r-dependencies` step of the GitHub Actions workflow (`.github/workflows/R-CMD-check.yml`).

To prevent any possible misinterpretation by the `pak` parser, all comments have been removed from this specific multiline block. The list now contains only the package names (`packrat`, `rcmdcheck`), each on its own line.

This is a stricter approach to avoid the persistent "Cannot parse packages" error.