### PR TITLE
Fix: Explicitly install rcmdcheck in CI workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -47,7 +47,9 @@ jobs:
         with:
           packages: |
             packrat
-            rcmdcheck
+
+      - name: Install rcmdcheck
+        run: Rscript -e "install.packages('rcmdcheck', repos = 'https://cloud.r-project.org')"
 
       - name: Restore R package dependencies (packrat)
         run: Rscript -e "packrat::restore()"


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow to ensure the `rcmdcheck` R package is installed reliably. Instead of relying on its inclusion in the `r-lib/actions/setup-r-dependencies` step, `rcmdcheck` is now installed explicitly using a dedicated `Rscript` command.

Changes in `.github/workflows/R-CMD-check.yml`:
- The `r-lib/actions/setup-r-dependencies` step is now configured to only install `packrat`.
- A new step `Install rcmdcheck` has been added, which runs `Rscript -e "install.packages('rcmdcheck', repos = 'https://cloud.r-project.org')"`.

This change provides a more direct and robust method for installing `rcmdcheck`, which is a crucial dependency for the `r-lib/actions/check-r-package` step. This aims to resolve the persistent "there is no package called 'rcmdcheck'" error.