### PR TITLE
Add rcmdcheck to suggested packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,4 +14,6 @@ License: MIT + file LICENSE
 LazyData: TRUE
 Imports:
     plyr
+Suggests:
+    rcmdcheck
 RoxygenNote: 5.0.1


### PR DESCRIPTION
## Summary
- add rcmdcheck to the package's Suggests field so CI installs it before running checks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df490cef708322ac46824a5700990e